### PR TITLE
Added ability to configure openid authentication with openid-provider an...

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -23,10 +23,22 @@
 
 <% case node['nagios']['server_auth_method'] -%>
 <% when "openid" -%>
+  <% openid = node['nagios']['openid'] -%>
   <Location />
     AuthName "Nagios Server"
     AuthType OpenID
-    require user <%= node['apache']['allowed_openids'].join(' ') %>
+    <% if openid['profile-url'] -%>
+      AuthOpenIDSingleIdP https://www.google.com/accounts/o8/id
+    <% end -%>
+    <% if openid['use-email-as-userid'] -%>
+      AuthOpenIDAXUsername email 
+    <% end -%>
+    <% if openid['email-pattern'] -%>
+      AuthOpenIDAXRequire email http://axschema.org/contact/email <%= openid['email-pattern'] %>
+      require valid-user
+    <% else -%>
+      require user <%= node['apache']['allowed_openids'].join(' ') %>
+    <% end -%>
     AuthOpenIDDBLocation <%= node['apache']['mod_auth_openid']['dblocation'] %>
   </Location>
 <% else -%>


### PR DESCRIPTION
@jblatt-verticloud 

Added three new attributes to allow configuring openid better:

Here is an example attributes file (please see the "openid" field of the top-level object):

{
    "run_list": ["recipe[nagios::server]"],

```
"nagios": {
    "nrpe": { "mon_host": [] },
    "sysadmins": [ { "id": "nagios", "nagios": { "email": "root@vertcloud.com", "htpasswd": "x", "openid": "https://www.google.com/accounts/o8/id/" } },
    { "id": "thiru", "nagios": { "nagios": { "email": "thiru@verticloud.com", "htpasswd": "x", "openid": "https://www.google.com/accounts/o8/id/" } } } ],
    "client_addresses": [ { "ipaddress": "10.3.8.11", "hostname": "host-a" }  ],
    "server_addresses": [],
    "services": [],
    "server_auth_method": "openid",
    "openid": {
        "profile-url": "https://www.google.com/accounts/o8/id",
        "use-email-as-userid": true,
        "email-pattern": "@verticloud.com$"
    },
    "hostgroups": [ { "name": "monitoring", "hosts": [] },
        { "name": "monitored", "hosts": [ "host-a" ] } ]
}
```

}

Thanks

Thiru
