### PR TITLE
made /etc/nagios3/conf.d owned by nagios instead of root.  

### DIFF
--- a/definitions/nagios_conf.rb
+++ b/definitions/nagios_conf.rb
@@ -22,7 +22,7 @@
 # limitations under the License.
 #
 define :nagios_conf, :variables => {}, :config_subdir => true do
-  
+
   conf_dir = params[:config_subdir] ? node['nagios']['config_dir'] : node['nagios']['conf_dir']
 
   template "#{conf_dir}/#{params[:name]}.cfg" do

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -54,8 +54,8 @@ end
 
 group node['nagios']['group'] do
   members [
-    node['nagios']['user'], 
-    web_srv == :nginx ? node['nginx']['user'] : node['apache']['user'] 
+    node['nagios']['user'],
+    web_srv == :nginx ? node['nginx']['user'] : node['apache']['user']
   ]
   action :modify
 end
@@ -103,14 +103,14 @@ bash "compile-nagios" do
 end
 
 directory "#{node['nagios']['conf_dir']}/conf.d" do
-  owner "root"
-  group "root"
+  owner node['nagios']['user']
+  group node['nagios']['group']
   mode 00755
 end
 
 %w{ cache_dir log_dir run_dir }.each do |dir|
-  
-  directory node['nagios'][dir] do 
+
+  directory node['nagios'][dir] do
     owner node['nagios']['user']
     group node['nagios']['group']
     mode 00755


### PR DESCRIPTION
without this fix the workbench listener cannot add new conf files to that dir in response to workbench startup/shutdown events.
